### PR TITLE
Обвязка для разработки без реального Chrome (Storybook, слои тестов, CI, dev)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 jobs:
   build:
     timeout-minutes: 30

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 jobs:
   biome:
     timeout-minutes: 15

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,3 +48,10 @@ jobs:
           npx concurrently -k -s first -n "SB,TEST" -c "magenta,green" \
           "npx http-server storybook-static --port 6006 --silent" \
           "npx wait-on tcp:127.0.0.1:6006 -l && npm run test-storybook -- --url http://127.0.0.1:6006"
+      - name: Upload Storybook
+        uses: actions/upload-artifact@v7
+        if: always()
+        with:
+          name: storybook-static
+          path: storybook-static
+          retention-days: 30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
 jobs:
   jest:
     timeout-minutes: 30

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ packages/
 .idea/
 .junie/
 .cursor/
-**/CLAUDE.md
 .jest/
 .plan/
 /coverage/

--- a/.rules/project-overview.md
+++ b/.rules/project-overview.md
@@ -59,4 +59,6 @@ Date: 2025‑09‑23
 
 - Redux Toolkit is used; remote Redux DevTools supported via `npm run redux-devtools` (connect to localhost:1024). State persistence via redux-persist-webextension-storage.
 - React 18 with CSS Modules and modern CSS reset. Themes live in `utils/themes`.
-- Storybook is available (webpack 5): `npm run storybook`; includes CSS Modules, a11y, and interactions addons.
+- Storybook (webpack 5) — основная среда разработки UI без реального Chrome: `npm run storybook`.
+  chrome.* замокан в `.storybook/fixtures/chrome-mock.ts` (история/закладки/storage/favicon),
+  стор — `storybook-fixtures/mock-store`. Включены аддоны a11y, docs, coverage, mcp.

--- a/.rules/testing.md
+++ b/.rules/testing.md
@@ -51,6 +51,26 @@ Add a new test (validated example):
 4. Remove temporary smoke tests when done.
 
 
+## Component tests (Testing Library, jsdom)
+
+- `*.spec.tsx` рядом с компонентом; рендер через `@testing-library/react`,
+  события — `@testing-library/user-event`, матчеры jest-dom подключены глобально
+  (`src/__setups__/testing-library.ts`).
+- Примеры: `src/components/Button/index.spec.tsx`, `src/components/Tabs/index.spec.tsx`.
+- Интеграционные тесты стора: `src/store/__tests__/store.spec.tsx`
+  (боевые редьюсеры + экшены + селекторы через `configureMockStore`).
+
+## Composition tests (Storybook play-функции)
+
+- Каждая стори с `play` — это композиционный тест; test-runner гоняет их
+  в headless Chromium вместе с a11y-проверками.
+- Контейнеры и целые экраны тестируются на моке chrome
+  (`.storybook/fixtures/chrome-mock.ts`) и реальном сторе
+  (`storybook-fixtures/mock-store`): см. `src/containers/NewTab/index.stories.tsx`.
+- Запуск: `npm run build-storybook`, поднять статику на :6006 и
+  `npm run test-storybook -- --url http://127.0.0.1:6006`
+  (нужен `npx playwright install chromium`).
+
 ## Browser/E2E tests (Playwright)
 
 - Config file: `playwright.config.ts`

--- a/.storybook/fixtures/chrome-mock.ts
+++ b/.storybook/fixtures/chrome-mock.ts
@@ -1,0 +1,194 @@
+// Мок chrome.* API для Storybook и других окружений без реального Chrome.
+// Данные истории генерируются @plq/faker — теми же шаблонами, что и в Jest-моках,
+// поэтому VCS/ITS/History-секции наполняются правдоподобными записями.
+import { History as MockHistory } from '@plq/faker'
+
+type Listener = (...args: never[]) => void
+
+function createEvent() {
+	const listeners = new Set<Listener>()
+
+	return {
+		addListener: (fn: Listener) => listeners.add(fn),
+		removeListener: (fn: Listener) => listeners.delete(fn),
+		hasListener: (fn: Listener) => listeners.has(fn),
+		hasListeners: () => listeners.size > 0,
+	}
+}
+
+function createStorageArea() {
+	let data: Record<string, unknown> = {}
+
+	return {
+		get(keys: string | string[] | null, callback?: (items: Record<string, unknown>) => void) {
+			const result: Record<string, unknown> = {}
+			const list = keys === null || keys === undefined ? Object.keys(data) : ([] as string[]).concat(keys)
+
+			for (const key of list) {
+				if (key in data) result[key] = data[key]
+			}
+
+			callback?.(result)
+
+			return Promise.resolve(result)
+		},
+		set(items: Record<string, unknown>, callback?: () => void) {
+			Object.assign(data, items)
+			callback?.()
+
+			return Promise.resolve()
+		},
+		remove(keys: string | string[], callback?: () => void) {
+			for (const key of ([] as string[]).concat(keys)) delete data[key]
+			callback?.()
+
+			return Promise.resolve()
+		},
+		clear(callback?: () => void) {
+			data = {}
+			callback?.()
+
+			return Promise.resolve()
+		},
+	}
+}
+
+type BookmarkNode = {
+	id: string
+	parentId?: string
+	title: string
+	url?: string
+	syncing: boolean
+	dateAdded: number
+}
+
+function createBookmarksMock() {
+	const nodes = new Map<string, BookmarkNode>()
+	let nextId = 1
+
+	const rootId = '0'
+	nodes.set(rootId, { id: rootId, title: '', syncing: false, dateAdded: 0 })
+	const barId = '1'
+	nodes.set(barId, { id: barId, parentId: rootId, title: 'Bookmarks bar', syncing: false, dateAdded: 0 })
+	nextId = 2
+
+	const childrenOf = (id: string): BookmarkNode[] =>
+		[...nodes.values()].filter((node) => node.parentId === id).map((node) => withChildren(node))
+
+	const withChildren = (node: BookmarkNode): BookmarkNode & { children?: BookmarkNode[] } =>
+		node.url ? { ...node } : { ...node, children: childrenOf(node.id) }
+
+	const require = (id: string): BookmarkNode => {
+		const node = nodes.get(id)
+
+		if (!node) throw new Error(`Bookmark node not found: ${id}`)
+
+		return node
+	}
+
+	return {
+		async getTree() {
+			return [withChildren(require(rootId))]
+		},
+		async getSubTree(id: string) {
+			return [withChildren(require(id))]
+		},
+		async get(id: string) {
+			return [{ ...require(id) }]
+		},
+		async search(query: { url?: string; title?: string; query?: string } | string) {
+			const q = typeof query === 'string' ? { query } : query
+
+			return [...nodes.values()]
+				.filter((node) => {
+					if (q.url) return node.url === q.url
+					if (q.title) return node.title === q.title
+					if (q.query) return node.title.includes(q.query) || (node.url ?? '').includes(q.query)
+
+					return false
+				})
+				.map((node) => ({ ...node }))
+		},
+		async create(details: { parentId?: string; title?: string; url?: string; index?: number }) {
+			const node: BookmarkNode = {
+				id: String(nextId++),
+				parentId: details.parentId ?? barId,
+				title: details.title ?? '',
+				url: details.url,
+				syncing: false,
+				dateAdded: 1700000000000 + nextId,
+			}
+			nodes.set(node.id, node)
+
+			return withChildren(node)
+		},
+		async update(id: string, changes: { title?: string; url?: string }) {
+			const node = require(id)
+			Object.assign(node, changes)
+
+			return { ...node }
+		},
+		async move(id: string, destination: { parentId?: string; index?: number }) {
+			const node = require(id)
+
+			if (destination.parentId) node.parentId = destination.parentId
+
+			return { ...node }
+		},
+		async remove(id: string) {
+			nodes.delete(id)
+		},
+		async removeTree(id: string) {
+			for (const child of childrenOf(id)) nodes.delete(child.id)
+			nodes.delete(id)
+		},
+		onCreated: createEvent(),
+		onChanged: createEvent(),
+		onRemoved: createEvent(),
+		onMoved: createEvent(),
+	}
+}
+
+function createHistoryMock() {
+	return {
+		async search(query: chrome.history.HistoryQuery) {
+			return new MockHistory(query).createMockItems()
+		},
+		getVisits: async () => [],
+		addUrl: async () => {},
+		deleteUrl: async () => {},
+		deleteRange: async () => {},
+		deleteAll: async () => {},
+		onVisited: createEvent(),
+		onVisitRemoved: createEvent(),
+	}
+}
+
+export function createChromeMock() {
+	return {
+		history: createHistoryMock(),
+		bookmarks: createBookmarksMock(),
+		storage: {
+			local: createStorageArea(),
+			sync: createStorageArea(),
+			session: createStorageArea(),
+			onChanged: createEvent(),
+		},
+		runtime: {
+			id: 'storybook-mock-extension',
+			// Favicon строит URL через chrome.runtime.getURL('/_favicon/') и добавляет
+			// query-параметры; статика Storybook отдаёт favicon-mock.svg, игнорируя query
+			getURL: () => new URL('/favicon-mock.svg', window.location.origin).toString(),
+			onMessage: createEvent(),
+			sendMessage: async () => {},
+		},
+	}
+}
+
+export function installChromeMock() {
+	const mock = createChromeMock() as unknown as typeof chrome
+
+	Object.assign(window, { chrome: mock })
+
+	return mock
+}

--- a/.storybook/fixtures/install-chrome-mock.ts
+++ b/.storybook/fixtures/install-chrome-mock.ts
@@ -1,0 +1,5 @@
+// Побочный модуль: устанавливает мок chrome.* до загрузки кода приложения.
+// Импортируется первым в .storybook/preview.tsx
+import { installChromeMock } from './chrome-mock'
+
+installChromeMock()

--- a/.storybook/fixtures/mock-store.tsx
+++ b/.storybook/fixtures/mock-store.tsx
@@ -4,11 +4,23 @@ import { Provider } from 'react-redux'
 import { preloadedState, reducer } from 'src/store'
 import { spyOn } from 'storybook/test'
 
-export const store = configureStore({
-	reducer,
-	preloadedState,
-})
+type MockState = Partial<typeof preloadedState>
 
-spyOn(store, 'dispatch')
+// Стор с боевыми редьюсерами, но без persistStore/PersistGate —
+// состояние живёт в памяти, dispatch обёрнут шпионом для assert'ов в play-тестах
+export function createMockStore(state: MockState = {}) {
+	const store = configureStore({
+		reducer,
+		preloadedState: { ...preloadedState, ...state },
+	})
 
-export const Mockstore = ({ children }: { children: ReactNode }) => <Provider store={store}>{children}</Provider>
+	spyOn(store, 'dispatch')
+
+	return store
+}
+
+export const store = createMockStore()
+
+export const Mockstore = ({ children, state }: { children: ReactNode; state?: MockState }) => (
+	<Provider store={state ? createMockStore(state) : store}>{children}</Provider>
+)

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,7 @@ const cssModulesOptions = {
 
 const config: StorybookConfig = {
 	stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+	staticDirs: ['./public'],
 	addons: [
 		'@storybook/addon-links',
 		'@storybook/addon-docs',

--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -1,1 +1,2 @@
 <div id="dialog"></div>
+<div id="tooltip"></div>

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,3 +1,4 @@
+import './fixtures/install-chrome-mock'
 import type { Preview } from '@storybook/react-webpack5'
 import { themes } from 'storybook/theming'
 import 'modern-css-reset/dist/reset.min.css'

--- a/.storybook/public/favicon-mock.svg
+++ b/.storybook/public/favicon-mock.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16">
+	<rect width="16" height="16" rx="4" fill="#5b8def"/>
+	<circle cx="8" cy="8" r="3.5" fill="#fff"/>
+</svg>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# Jared — руководство для AI-агента
+
+Chrome-расширение (Manifest V3), заменяющее новую вкладку: секции с историей браузера
+(VCS/ITS-провайдеры: GitHub, GitLab, Jira, YouTrack), закладками и настройками.
+React 19 + Redux Toolkit 2 + CSS Modules, сборка webpack (webextension-toolbox).
+
+## Главное правило
+
+**Реальный Chrome для разработки не нужен.** Вся среда построена так, чтобы код можно
+было разрабатывать и проверять без запуска расширения:
+
+- **Storybook** — основная среда разработки UI (компоненты и целые экраны на моках chrome.*)
+- **Jest** — unit-тесты утилит, интеграционные тесты стора, компонентные тесты (Testing Library)
+- **Storybook test-runner** — композиционные interaction-тесты (play-функции) в headless Chromium
+- **Playwright** (`playwright/`) — e2e с реальным собранным расширением; медленный слой, запускается точечно
+
+## Команды
+
+| Команда | Что делает |
+|---|---|
+| `npm ci` | установка зависимостей (Node из `.nvmrc`) |
+| `npm run lint` / `npm run lint:fix` | Biome: линт + формат (конфиг `biome.json`) |
+| `npx tsc --noEmit` | типизация (TypeScript 6, strict) |
+| `npx jest` | все Jest-тесты (`src/**/*.spec.ts(x)`) |
+| `npx jest путь/к/файлу.spec.ts` | один файл |
+| `npm run storybook` | Storybook на :6006 с HMR |
+| `npm run build-storybook` | статическая сборка Storybook |
+| `npm run test-storybook -- --url http://127.0.0.1:6006` | interaction-тесты по запущенному/отданному Storybook (нужен `npx playwright install chromium`) |
+| `npm run build` | сборка расширения → `dist/chrome` + zip в `packages/` |
+| `npm run dev` | watch-сборка в `dist/chrome` с автоперезагрузкой загруженного расширения |
+
+Полный цикл interaction-тестов без dev-сервера:
+
+```sh
+npm run build-storybook
+npx concurrently -k -s first "npx http-server storybook-static --port 6006 --silent" \
+  "npx wait-on tcp:127.0.0.1:6006 && npm run test-storybook -- --url http://127.0.0.1:6006"
+```
+
+## Слои тестирования — что куда класть
+
+1. **Unit (утилиты, процессоры истории)** — `*.spec.ts` рядом с кодом в `src/utils/**`.
+   Chrome API замокан в `src/__setups__/chrome.ts`, данные — `@plq/faker` и `src/__mocks__/history.ts`.
+2. **Интеграция стора** — `src/store/__tests__/*.spec.tsx`: боевые редьюсеры + экшены + селекторы
+   через `configureMockStore` (без persist и браузера).
+3. **Компонентные (jsdom)** — `*.spec.tsx` рядом с компонентом: Testing Library +
+   `@testing-library/jest-dom` (подключён в `src/__setups__/testing-library.ts`).
+4. **Композиционные (Storybook play)** — `*.stories.tsx`: связки компонентов и контейнеры
+   с реальным стором (`storybook-fixtures/mock-store`) и моком chrome
+   (`.storybook/fixtures/chrome-mock.ts`). Пример целого экрана: `src/containers/NewTab/index.stories.tsx`.
+5. **E2E (Playwright)** — `playwright/`: реальный Chrome с собранным `dist/chrome`.
+
+Test-runner дополнительно гоняет по каждой стори a11y-проверки (addon-a11y) — падения
+доступности являются ошибками, чини компонент, а не тест.
+
+## Моки chrome.\*
+
+- Jest: `src/__setups__/chrome.ts` (`jest-webextension-mock` + генератор истории). Новые API добавляй туда.
+- Storybook: `.storybook/fixtures/chrome-mock.ts` — in-memory `history`, `bookmarks`, `storage`,
+  `runtime.getURL` (заглушка фавиконок из `.storybook/public/favicon-mock.svg`).
+  Устанавливается первым импортом в `.storybook/preview.tsx`.
+- Обёртки над браузерными API живут в `src/utils/api/` и резолвят `window.browser ?? window.chrome`
+  **лениво** — код приложения не должен обращаться к `chrome.*` напрямую (кроме типов).
+
+## Конвенции
+
+- Импорты только через алиасы: `components/*`, `containers/*`, `utils/*`, `store/*`, `types/*`,
+  `src/*`, `package`, `storybook-fixtures/*`. Новый алиас синхронизируй в трёх местах:
+  `tsconfig.json` (paths), `create-webpack-config.js` (resolve.alias), `jest.config.ts` (moduleNameMapper).
+- Стиль кода — Biome: табы, одинарные кавычки, без точек с запятой. Не спорь с форматтером,
+  запускай `npm run lint:fix`.
+- Компоненты — именованные функции (`export default function Name()`), у интерактивных элементов
+  обязательны `type="button"`, доступные имена и `data-testid` для тестов.
+- Redux: typescript-fsa экшены + reducerWithInitialState (см. `src/store/`), селекторы через reselect.
+- Стори: `Meta`/`StoryObj` из `@storybook/react-webpack5`, интеракции из `storybook/test`.
+
+## Перед коммитом
+
+`npm run lint && npx tsc --noEmit && npx jest` — минимум. Если менял UI — прогони ещё
+build-storybook + test-storybook. Если менял сборку — `npm run build`.
+
+Подробнее: `.rules/project-overview.md`, `.rules/testing.md`, `.rules/dev-policy.md`.

--- a/README.md
+++ b/README.md
@@ -19,24 +19,64 @@ Supported browsers:
 - Chrome
 
 ## Install
-	$ npm install
+
+```sh
+npm ci
+```
+
+Node-версия — в `.nvmrc` (`nvm use`).
 
 ## Development
-    npm run dev chrome
-[//]: # (npm run dev firefox)
-[//]: # (npm run dev opera)
-[//]: # (npm run dev edge)
+
+Основная среда разработки UI — **Storybook** (реальный Chrome не нужен,
+`chrome.*` замокан):
+
+```sh
+npm run storybook   # http://localhost:6006, с HMR
+```
+
+Разработка в реальном Chrome:
+
+```sh
+npm run dev
+```
+
+Watch-сборка кладёт распакованное расширение в `dist/chrome` — загрузите его один раз
+через `chrome://extensions` → «Load unpacked», дальше расширение перезагружается
+автоматически при каждом изменении кода (webpack-webextension-plugin).
+
+## Tests
+
+```sh
+npm run lint        # Biome (линт + формат)
+npx tsc --noEmit    # типизация
+npx jest            # unit + интеграционные + компонентные тесты
+```
+
+Композиционные interaction-тесты (Storybook + headless Chromium):
+
+```sh
+npx playwright install chromium   # один раз
+npm run build-storybook
+npx concurrently -k -s first "npx http-server storybook-static --port 6006 --silent" \
+  "npx wait-on tcp:127.0.0.1:6006 && npm run test-storybook -- --url http://127.0.0.1:6006"
+```
+
+E2E с реальным расширением: `npm run build && npm run test:playwright`.
 
 ## Build
-    npm run build chrome
-[//]: # (npm run build firefox)
-[//]: # (npm run build opera)
-[//]: # (npm run build edge)
 
-## Environment
+```sh
+npm run build
+```
 
-The build tool also defines a variable named `process.env.NODE_ENV` in your scripts. 
+Готовый zip — в `packages/`, распакованная сборка — в `dist/chrome`.
+Каждый CI-прогон workflow **Build** также публикует установочный артефакт
+`packages` (Actions → Build → Artifacts): скачайте, распакуйте zip и установите
+через «Load unpacked».
 
 ## Docs
 
-* [webextension-toolbox](https://github.com/HaNdTriX/webextension-toolbox)
+* [CLAUDE.md](CLAUDE.md) — карта проекта и правила для AI-агентов (и людей)
+* [.rules/](.rules) — обзор проекта, тестирование, конвенции
+* [webextension-toolbox](https://github.com/webextension-toolbox/webextension-toolbox)

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,6 +9,7 @@ const config: Config = {
 	},
 
 	setupFiles: ['./__setups__/chrome.ts'],
+	setupFilesAfterEnv: ['./__setups__/testing-library.ts'],
 
 	clearMocks: true,
 
@@ -19,6 +20,7 @@ const config: Config = {
 	moduleFileExtensions: ['js', 'mjs', 'cjs', 'jsx', 'ts', 'tsx', 'json'],
 
 	moduleNameMapper: {
+		'^nanoid$': '<rootDir>/__mocks__/nanoid.ts',
 		'\\.svg$': '<rootDir>/__mocks__/svg.ts',
 		'\\.css$': 'identity-obj-proxy',
 		'^store/(.*)$': '<rootDir>/store/$1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,10 @@
 				"@storybook/addon-webpack5-compiler-babel": "^4.0.1",
 				"@storybook/react-webpack5": "^10.5.10",
 				"@storybook/test-runner": "^0.24.4",
+				"@testing-library/dom": "^10.4.1",
+				"@testing-library/jest-dom": "^7.0.1",
+				"@testing-library/react": "^16.3.2",
+				"@testing-library/user-event": "^14.6.5",
 				"@types/chrome": "^0.2.7",
 				"@types/firefox-webext-browser": "^143.0.0",
 				"@types/jest": "^30.0.0",
@@ -10869,59 +10873,29 @@
 			}
 		},
 		"node_modules/@testing-library/dom": {
-			"version": "9.3.3",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.3.tgz",
-			"integrity": "sha512-fB0R+fa3AUqbLHWyxXa2kGVtf1Fe1ZZFr0Zp6AIbIAzXb2mKbEXl+PCQNUOaq5lbTab5tfctfXRNsWXxa2f7Aw==",
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
 			"dev": true,
-			"peer": true,
+			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.10.4",
 				"@babel/runtime": "^7.12.5",
 				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.1.3",
-				"chalk": "^4.1.0",
+				"aria-query": "5.3.0",
 				"dom-accessibility-api": "^0.5.9",
 				"lz-string": "^1.5.0",
+				"picocolors": "1.1.1",
 				"pretty-format": "^27.0.2"
 			},
 			"engines": {
-				"node": ">=14"
-			}
-		},
-		"node_modules/@testing-library/dom/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/@testing-library/dom/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
+				"node": ">=18"
 			}
 		},
 		"node_modules/@testing-library/jest-dom": {
-			"version": "6.9.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
-			"integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+			"integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10933,9 +10907,18 @@
 				"redent": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=14",
+				"node": ">=22",
 				"npm": ">=6",
 				"yarn": ">=1"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": ">=10 <11",
+				"vitest": ">= 0.32"
+			},
+			"peerDependenciesMeta": {
+				"vitest": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@testing-library/jest-dom/node_modules/@adobe/css-tools": {
@@ -10951,6 +10934,34 @@
 			"integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/@testing-library/react": {
+			"version": "16.3.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+			"integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": "^10.0.0",
+				"@types/react": "^18.0.0 || ^19.0.0",
+				"@types/react-dom": "^18.0.0 || ^19.0.0",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/@testing-library/user-event": {
 			"version": "14.6.5",
@@ -12777,12 +12788,13 @@
 			}
 		},
 		"node_modules/aria-query": {
-			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-			"integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
-				"deep-equal": "^2.0.5"
+				"dequal": "^2.0.3"
 			}
 		},
 		"node_modules/arr-diff": {
@@ -12810,19 +12822,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/array-buffer-byte-length": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
-			"integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"is-array-buffer": "^3.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/array-flatten": {
@@ -12951,18 +12950,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.1.0"
-			}
-		},
-		"node_modules/available-typed-arrays": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-			"integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/axe-core": {
@@ -15398,38 +15385,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/deep-equal": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
-			"integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
-			"dev": true,
-			"dependencies": {
-				"array-buffer-byte-length": "^1.0.0",
-				"call-bind": "^1.0.5",
-				"es-get-iterator": "^1.1.3",
-				"get-intrinsic": "^1.2.2",
-				"is-arguments": "^1.1.1",
-				"is-array-buffer": "^3.0.2",
-				"is-date-object": "^1.0.5",
-				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.2",
-				"isarray": "^2.0.5",
-				"object-is": "^1.1.5",
-				"object-keys": "^1.1.1",
-				"object.assign": "^4.1.4",
-				"regexp.prototype.flags": "^1.5.1",
-				"side-channel": "^1.0.4",
-				"which-boxed-primitive": "^1.0.2",
-				"which-collection": "^1.0.1",
-				"which-typed-array": "^1.1.13"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/deepmerge": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -15524,23 +15479,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/define-properties": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-			"integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-			"dev": true,
-			"dependencies": {
-				"define-data-property": "^1.0.1",
-				"has-property-descriptors": "^1.0.0",
-				"object-keys": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/define-property": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
@@ -15576,6 +15514,7 @@
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -15986,26 +15925,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-get-iterator": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-			"integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.3",
-				"has-symbols": "^1.0.3",
-				"is-arguments": "^1.1.1",
-				"is-map": "^2.0.2",
-				"is-set": "^2.0.2",
-				"is-string": "^1.0.7",
-				"isarray": "^2.0.5",
-				"stop-iteration-iterator": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/es-module-lexer": {
@@ -16954,15 +16873,6 @@
 				}
 			}
 		},
-		"node_modules/for-each": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-			"integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-			"dev": true,
-			"dependencies": {
-				"is-callable": "^1.1.3"
-			}
-		},
 		"node_modules/for-in": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -17273,15 +17183,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/functions-have-names": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
 			"dev": true,
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -17627,15 +17528,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/has-bigints": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/has-flag": {
@@ -18360,20 +18252,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/internal-slot": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
-			"integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
-			"dev": true,
-			"dependencies": {
-				"get-intrinsic": "^1.2.2",
-				"hasown": "^2.0.0",
-				"side-channel": "^1.0.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/ipaddr.js": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -18395,53 +18273,11 @@
 				"node": ">= 0.10"
 			}
 		},
-		"node_modules/is-arguments": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-			"integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-array-buffer": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
-			"integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.2.0",
-				"is-typed-array": "^1.1.10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
 			"dev": true
-		},
-		"node_modules/is-bigint": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-			"dev": true,
-			"dependencies": {
-				"has-bigints": "^1.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/is-binary-path": {
 			"version": "2.1.0",
@@ -18455,39 +18291,11 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/is-boolean-object": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-			"integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
 			"dev": true
-		},
-		"node_modules/is-callable": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-			"integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/is-core-module": {
 			"version": "2.16.2",
@@ -18515,21 +18323,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/is-date-object": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-			"integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-			"dev": true,
-			"dependencies": {
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-descriptor": {
@@ -18644,15 +18437,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-map": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-			"integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -18661,21 +18445,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
-			}
-		},
-		"node_modules/is-number-object": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-			"integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-			"dev": true,
-			"dependencies": {
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-plain-obj": {
@@ -18694,43 +18463,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/is-regex": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-			"integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-set": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-			"integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-shared-array-buffer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-stream": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
@@ -18743,79 +18475,12 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/is-string": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-			"integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-			"dev": true,
-			"dependencies": {
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-symbol": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-			"integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-			"dev": true,
-			"dependencies": {
-				"has-symbols": "^1.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-typed-array": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-			"integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
-			"dev": true,
-			"dependencies": {
-				"which-typed-array": "^1.1.11"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/is-weakmap": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-			"integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-			"dev": true,
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/is-weakset": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-			"integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"get-intrinsic": "^1.1.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/is-what": {
 			"version": "3.14.1",
@@ -18843,12 +18508,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/isarray": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-			"dev": true
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
@@ -24092,31 +23751,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/object-is": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-			"integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-			"dev": true,
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/object-visit": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -24136,24 +23770,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/object.assign": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"has-symbols": "^1.0.3",
-				"object-keys": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/object.pick": {
@@ -27239,23 +26855,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/regexp.prototype.flags": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-			"integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
-			"dev": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.2.0",
-				"set-function-name": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/regexpu-core": {
 			"version": "6.4.0",
 			"resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
@@ -28068,20 +27667,6 @@
 				"node": ">= 0.4"
 			}
 		},
-		"node_modules/set-function-name": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-			"integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
-			"dev": true,
-			"dependencies": {
-				"define-data-property": "^1.0.1",
-				"functions-have-names": "^1.2.3",
-				"has-property-descriptors": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/set-getter": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.1.tgz",
@@ -28667,18 +28252,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/stop-iteration-iterator": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-			"integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-			"dev": true,
-			"dependencies": {
-				"internal-slot": "^1.0.4"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/storybook": {
 			"version": "10.5.10",
 			"resolved": "https://registry.npmjs.org/storybook/-/storybook-10.5.10.tgz",
@@ -28728,35 +28301,39 @@
 				}
 			}
 		},
-		"node_modules/storybook/node_modules/@testing-library/dom": {
-			"version": "10.4.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-			"integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+		"node_modules/storybook/node_modules/@adobe/css-tools": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+			"integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/storybook/node_modules/@testing-library/jest-dom": {
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+			"integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.10.4",
-				"@babel/runtime": "^7.12.5",
-				"@types/aria-query": "^5.0.1",
-				"aria-query": "5.3.0",
-				"dom-accessibility-api": "^0.5.9",
-				"lz-string": "^1.5.0",
-				"picocolors": "1.1.1",
-				"pretty-format": "^27.0.2"
+				"@adobe/css-tools": "^4.4.0",
+				"aria-query": "^5.0.0",
+				"css.escape": "^1.5.1",
+				"dom-accessibility-api": "^0.6.3",
+				"picocolors": "^1.1.1",
+				"redent": "^3.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=14",
+				"npm": ">=6",
+				"yarn": ">=1"
 			}
 		},
-		"node_modules/storybook/node_modules/aria-query": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+		"node_modules/storybook/node_modules/dom-accessibility-api": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+			"integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
 			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"dequal": "^2.0.3"
-			}
+			"license": "MIT"
 		},
 		"node_modules/storybook/node_modules/semver": {
 			"version": "7.8.5",
@@ -32444,62 +32021,12 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/which-boxed-primitive": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-			"integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-			"dev": true,
-			"dependencies": {
-				"is-bigint": "^1.0.1",
-				"is-boolean-object": "^1.1.0",
-				"is-number-object": "^1.0.4",
-				"is-string": "^1.0.5",
-				"is-symbol": "^1.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/which-collection": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-			"integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-			"dev": true,
-			"dependencies": {
-				"is-map": "^2.0.1",
-				"is-set": "^2.0.1",
-				"is-weakmap": "^2.0.1",
-				"is-weakset": "^2.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/which-module": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
 			"integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/which-typed-array": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
-			"integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
-			"dev": true,
-			"dependencies": {
-				"available-typed-arrays": "^1.0.5",
-				"call-bind": "^1.0.4",
-				"for-each": "^0.3.3",
-				"gopd": "^1.0.1",
-				"has-tostringtag": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/wildcard": {
 			"version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -40,10 +40,15 @@
 		"@storybook/addon-coverage": "^3.0.2",
 		"@storybook/addon-docs": "^10.5.10",
 		"@storybook/addon-links": "^10.5.10",
+		"@storybook/addon-mcp": "^0.7.0",
 		"@storybook/addon-styling-webpack": "^3.0.2",
 		"@storybook/addon-webpack5-compiler-babel": "^4.0.1",
 		"@storybook/react-webpack5": "^10.5.10",
 		"@storybook/test-runner": "^0.24.4",
+		"@testing-library/dom": "^10.4.1",
+		"@testing-library/jest-dom": "^7.0.1",
+		"@testing-library/react": "^16.3.2",
+		"@testing-library/user-event": "^14.6.5",
 		"@types/chrome": "^0.2.7",
 		"@types/firefox-webext-browser": "^143.0.0",
 		"@types/jest": "^30.0.0",
@@ -85,8 +90,7 @@
 		"typescript": "^6.0.3",
 		"typescript-plugin-css-modules": "^5.2.0",
 		"wait-on": "^9.1.0",
-		"webpack-merge": "^6.0.1",
-		"@storybook/addon-mcp": "^0.7.0"
+		"webpack-merge": "^6.0.1"
 	},
 	"dependencies": {
 		"@plq/array-functions": "^1.5.1",

--- a/src/__mocks__/nanoid.ts
+++ b/src/__mocks__/nanoid.ts
@@ -1,0 +1,13 @@
+// CJS-шим nanoid для Jest: боевой nanoid@6 — ESM-only.
+// Поведение (uid из 21 url-safe символа) совпадает по контракту
+const alphabet = 'useandom-26T198340PX75pxJACKVERYMINDBUSHWOLF_GQZbfghjklqvwyzrict'
+
+export const nanoid = (size = 21) => {
+	let id = ''
+
+	for (let i = 0; i < size; i++) {
+		id += alphabet[Math.floor(Math.random() * alphabet.length)]
+	}
+
+	return id
+}

--- a/src/__setups__/testing-library.ts
+++ b/src/__setups__/testing-library.ts
@@ -1,0 +1,2 @@
+// Подключает jest-dom матчеры (toBeInTheDocument и т.п.) во все тесты
+import '@testing-library/jest-dom'

--- a/src/components/Bookmark/index.stories.tsx
+++ b/src/components/Bookmark/index.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import Bookmark from 'components/Bookmark'
+import { expect, fn, within } from 'storybook/test'
+
+const meta: Meta<typeof Bookmark> = {
+	title: 'UI/Bookmark',
+	component: Bookmark,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs', 'ui'],
+	args: {
+		onEditClick: fn(),
+		onRemoveClick: fn(),
+	},
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: {
+		id: '42',
+		title: 'Jared — better new tab',
+		url: 'https://github.com/Akurganow/jared',
+		syncing: false,
+	},
+	play: async ({ canvasElement, args, userEvent }) => {
+		const canvas = within(canvasElement)
+
+		await userEvent.click(canvas.getByTitle('Edit bookmark'))
+		await expect(args.onEditClick).toHaveBeenCalled()
+
+		await userEvent.click(canvas.getByTitle('Remove bookmark'))
+		await expect(args.onRemoveClick).toHaveBeenCalled()
+	},
+}

--- a/src/components/Bookmark/index.tsx
+++ b/src/components/Bookmark/index.tsx
@@ -8,11 +8,15 @@ interface BookmarkProps extends chrome.bookmarks.BookmarkTreeNode {
 	onRemoveClick: (event: ReactMouseEvent<HTMLButtonElement>) => void
 }
 
-export default function Bookmark({ id, title, url, onRemoveClick, onEditClick }: BookmarkProps) {
+// кнопки действий — сиблинги ссылки, а не её дети:
+// вложенные интерактивные элементы ломают доступность (nested-interactive)
+export default function Bookmark({ title, url, onRemoveClick, onEditClick }: BookmarkProps) {
 	return (
-		<a key={id} className={cn(st.bookmark)} href={url}>
-			{url && <Favicon href={url} size={16} className={cn(st.favicon)} />}
-			{title}
+		<div className={cn(st.bookmark)} data-testid="Bookmark">
+			<a className={cn(st.link)} href={url}>
+				{url && <Favicon href={url} size={16} className={cn(st.favicon)} />}
+				{title}
+			</a>
 			<div className={cn(st.actions)}>
 				<button type="button" onClick={onRemoveClick} className={cn(st.action)} title="Remove bookmark">
 					×
@@ -21,6 +25,6 @@ export default function Bookmark({ id, title, url, onRemoveClick, onEditClick }:
 					✎
 				</button>
 			</div>
-		</a>
+		</div>
 	)
 }

--- a/src/components/Bookmark/styles.module.css
+++ b/src/components/Bookmark/styles.module.css
@@ -17,6 +17,14 @@
 	filter: brightness(1.1);
 }
 
+.link {
+	color: currentColor;
+	text-decoration: none;
+	display: flex;
+	align-items: center;
+	flex: 1;
+}
+
 .favicon {
 	margin-right: 0.5rem;
 }

--- a/src/components/Button/index.spec.tsx
+++ b/src/components/Button/index.spec.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Button from 'components/Button'
+
+describe('Button', () => {
+	test('рендерит содержимое и вызывает onClick', async () => {
+		const user = userEvent.setup()
+		const handleClick = jest.fn()
+
+		render(<Button onClick={handleClick}>Click me</Button>)
+
+		const button = screen.getByTestId('Button')
+		expect(button).toBeInTheDocument()
+		expect(button).toHaveTextContent('Click me')
+
+		await user.click(button)
+		expect(handleClick).toHaveBeenCalledTimes(1)
+	})
+
+	test('в состоянии disabled не реагирует на клики', async () => {
+		const user = userEvent.setup()
+		const handleClick = jest.fn()
+
+		render(
+			<Button disabled onClick={handleClick}>
+				Disabled
+			</Button>,
+		)
+
+		const button = screen.getByTestId('Button')
+		expect(button).toBeDisabled()
+
+		await user.click(button).catch(() => {})
+		expect(handleClick).not.toHaveBeenCalled()
+	})
+})

--- a/src/components/Favicon/index.stories.tsx
+++ b/src/components/Favicon/index.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import Favicon from 'components/Favicon'
+
+// В Storybook chrome.runtime.getURL замокан и отдаёт статичную заглушку
+const meta: Meta<typeof Favicon> = {
+	title: 'UI/Favicon',
+	component: Favicon,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs', 'ui'],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: {
+		href: 'https://github.com',
+		size: 32,
+	},
+}

--- a/src/components/Loader/index.stories.tsx
+++ b/src/components/Loader/index.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import Loader from 'components/Loader'
+
+const meta: Meta<typeof Loader> = {
+	title: 'UI/Loader',
+	component: Loader,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs', 'ui'],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/src/components/PinButton/index.stories.tsx
+++ b/src/components/PinButton/index.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import PinButton from 'components/PinButton'
+import { expect, fn, within } from 'storybook/test'
+
+const meta: Meta<typeof PinButton> = {
+	title: 'UI/PinButton',
+	component: PinButton,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs', 'ui'],
+	args: {
+		onClick: fn(),
+	},
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Unpinned: Story = {
+	args: {
+		pinned: false,
+	},
+	play: async ({ canvasElement, args, userEvent }) => {
+		const canvas = within(canvasElement)
+		const button = canvas.getByRole('button')
+
+		await userEvent.click(button)
+		await expect(args.onClick).toHaveBeenCalled()
+	},
+}
+
+export const Pinned: Story = {
+	args: {
+		pinned: true,
+	},
+}

--- a/src/components/PinButton/index.tsx
+++ b/src/components/PinButton/index.tsx
@@ -6,9 +6,9 @@ import st from './styles.module.css'
 export interface PinButtonProps extends DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
 	pinned?: boolean
 }
-export default function PiButton({ pinned, className, ...props }: PinButtonProps) {
+export default function PinButton({ pinned, className, ...props }: PinButtonProps) {
 	return (
-		<button {...props} className={cn(className, st.button)}>
+		<button type="button" aria-label={pinned ? 'Unpin' : 'Pin'} {...props} className={cn(className, st.button)}>
 			<SVGIcon name={pinned ? 'unpin' : 'pin'} />
 		</button>
 	)

--- a/src/components/SidebarItem/index.stories.tsx
+++ b/src/components/SidebarItem/index.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import SidebarItem from 'components/SidebarItem'
+import { Mockstore } from 'storybook-fixtures/mock-store'
+
+const meta: Meta<typeof SidebarItem> = {
+	title: 'UI/SidebarItem',
+	component: SidebarItem,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs', 'ui'],
+	decorators: [
+		(Story) => (
+			<Mockstore state={{}}>
+				<Story />
+			</Mockstore>
+		),
+	],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	args: {
+		name: 'settings',
+		icon: 'settings',
+		tooltip: null,
+	},
+}
+
+export const WithTooltip: Story = {
+	args: {
+		name: 'download',
+		icon: 'download',
+		tooltip: <span>Downloads</span>,
+	},
+}

--- a/src/components/Tabs/index.spec.tsx
+++ b/src/components/Tabs/index.spec.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import Tabs, { type Tab } from 'components/Tabs'
+
+const items: Tab[] = [
+	{ id: 'first', title: 'First', children: <div>First content</div> },
+	{ id: 'second', title: 'Second', children: <div>Second content</div> },
+	{ id: 'disabled', title: 'Disabled', disabled: true },
+]
+
+describe('Tabs', () => {
+	test('показывает первый таб активным', () => {
+		render(<Tabs items={items} withoutPreflight />)
+
+		expect(screen.getByText('First content')).toBeVisible()
+		expect(screen.getAllByTestId('Tabs:Item')).toHaveLength(3)
+	})
+
+	test('переключает контент и сообщает id таба', async () => {
+		const user = userEvent.setup()
+		const onTabSwitched = jest.fn()
+
+		render(<Tabs items={items} onTabSwitched={onTabSwitched} withoutPreflight />)
+
+		await user.click(screen.getByRole('button', { name: 'Second' }))
+
+		expect(onTabSwitched).toHaveBeenCalledWith('second')
+		expect(screen.getByTestId('Tabs:ContentItem')).toHaveAttribute('data-index', '1')
+	})
+
+	test('задизейбленный таб не переключается', async () => {
+		const user = userEvent.setup()
+		const onTabSwitched = jest.fn()
+
+		render(<Tabs items={items} onTabSwitched={onTabSwitched} withoutPreflight />)
+
+		await user.click(screen.getByRole('button', { name: 'Disabled' })).catch(() => {})
+
+		expect(onTabSwitched).not.toHaveBeenCalled()
+	})
+})

--- a/src/containers/Dialogs/SectionDialog/index.tsx
+++ b/src/containers/Dialogs/SectionDialog/index.tsx
@@ -1,4 +1,6 @@
-import { createPersistedState } from '@plq/use-persisted-state'
+// импорт CJS-сборки напрямую: ESM-обёртка пакета несовместима с webpack-interop
+// (см. https://github.com/Akurganow/use-persisted-state — кандидат на фикс апстрима)
+import createPersistedState from '@plq/use-persisted-state/lib'
 import storage from '@plq/use-persisted-state/lib/storages/local-storage'
 import Button from 'components/Button'
 import Dialog, { DialogBody, DialogFooter } from 'components/Dialog'

--- a/src/containers/NewTab/index.stories.tsx
+++ b/src/containers/NewTab/index.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import NewTab from 'containers/NewTab'
+import { expect, waitFor, within } from 'storybook/test'
+import { Mockstore } from 'storybook-fixtures/mock-store'
+
+// Композиционная стори: весь экран новой вкладки на моках chrome.* —
+// секции сами запрашивают историю/закладки у замоканного браузера
+const meta: Meta<typeof NewTab> = {
+	title: 'Containers/NewTab',
+	component: NewTab,
+	parameters: {
+		layout: 'fullscreen',
+	},
+	tags: ['autodocs', 'container'],
+	decorators: [
+		(Story) => (
+			<Mockstore state={{}}>
+				<Story />
+			</Mockstore>
+		),
+	],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+	play: async ({ canvasElement }) => {
+		const canvas = within(canvasElement)
+
+		// секции получают данные из мока асинхронно
+		await waitFor(
+			async () => {
+				const items = canvas.getAllByTestId('HistoryItem')
+
+				await expect(items.length).toBeGreaterThan(0)
+			},
+			{ timeout: 10000 },
+		)
+	},
+}
+
+export const EditMode: Story = {
+	play: async ({ canvasElement, userEvent }) => {
+		const canvas = within(canvasElement)
+
+		// первая кнопка в сайдбаре включает режим редактирования —
+		// секции должны показать свои заголовки
+		const sidebarButtons = canvas.getAllByRole('button')
+		await userEvent.click(sidebarButtons[0])
+
+		await waitFor(async () => {
+			const headings = canvas.getAllByRole('heading')
+
+			await expect(headings.length).toBeGreaterThan(0)
+		})
+	},
+}

--- a/src/containers/Sidebar/index.stories.tsx
+++ b/src/containers/Sidebar/index.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5'
+import Sidebar from 'containers/Sidebar'
+import { Mockstore } from 'storybook-fixtures/mock-store'
+
+const meta: Meta<typeof Sidebar> = {
+	title: 'Containers/Sidebar',
+	component: Sidebar,
+	parameters: {
+		layout: 'centered',
+	},
+	tags: ['autodocs', 'container'],
+	decorators: [
+		(Story) => (
+			<Mockstore state={{}}>
+				<Story />
+			</Mockstore>
+		),
+	],
+}
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/src/store/__tests__/store.spec.tsx
+++ b/src/store/__tests__/store.spec.tsx
@@ -1,0 +1,31 @@
+import { closeDialog, openDialog } from 'store/actions/dialogs'
+import { switchEditMode } from 'store/actions/sections'
+import { createDialogSelector } from 'store/selectors/dialogs'
+import { selectedEditMode } from 'store/selectors/sections'
+import type { RootState } from 'store/types'
+import { configureMockStore } from './mock-store'
+
+// Интеграционные тесты стора: боевые редьюсеры + экшены + селекторы,
+// без браузера и без persist
+describe('store integration', () => {
+	test('открытие и закрытие диалога отражается в селекторе', () => {
+		const store = configureMockStore()
+
+		expect(createDialogSelector(store.getState() as RootState, 'settings')).toBe(false)
+
+		store.dispatch(openDialog('settings'))
+		expect(createDialogSelector(store.getState() as RootState, 'settings')).toBe(true)
+
+		store.dispatch(closeDialog('settings'))
+		expect(createDialogSelector(store.getState() as RootState, 'settings')).toBe(false)
+	})
+
+	test('переключение режима редактирования секций', () => {
+		const store = configureMockStore()
+
+		expect(selectedEditMode(store.getState() as RootState)).toBe(false)
+
+		store.dispatch(switchEditMode(true))
+		expect(selectedEditMode(store.getState() as RootState)).toBe(true)
+	})
+})

--- a/src/utils/api/bookmarks/index.ts
+++ b/src/utils/api/bookmarks/index.ts
@@ -1,7 +1,11 @@
 import type { BookmarkCreateArg, BookmarkSearchQuery, Browser } from '../types'
 
 export default class Bookmarks {
-	private readonly browser: Browser = (window.browser ?? window.chrome) as unknown as Browser
+	// ленивое разрешение: даёт окружениям без реального Chrome (Storybook, jsdom)
+	// установить мок window.chrome до первого обращения к API
+	private get browser(): Browser {
+		return (window.browser ?? window.chrome) as unknown as Browser
+	}
 
 	public async getTree() {
 		return await this.browser.bookmarks.getTree()

--- a/src/utils/api/history/index.ts
+++ b/src/utils/api/history/index.ts
@@ -2,7 +2,11 @@ import type { ITSHistoryItem, ProcessConfig, VCSHistoryItem } from 'types/histor
 import type { Browser, HistoryItem, HistoryQuery } from '../types'
 
 export default class History {
-	private readonly browser: Browser = (window.browser ?? window.chrome) as unknown as Browser
+	// ленивое разрешение: даёт окружениям без реального Chrome (Storybook, jsdom)
+	// установить мок window.chrome до первого обращения к API
+	private get browser(): Browser {
+		return (window.browser ?? window.chrome) as unknown as Browser
+	}
 
 	public async search(query: chrome.history.HistoryQuery) {
 		return await this.browser.history.search(query)


### PR DESCRIPTION
## Что сделано

Второй PR (stacked поверх #19 — base этого PR указывает на его ветку; после мержа #19 GitHub автоматически перенацелит на `master`). Цель — среда, в которой облачный агент (и человек) разрабатывает расширение **без запуска реального Chrome**.

### Storybook как основная среда разработки

- **Мок `chrome.*` для Storybook** (`.storybook/fixtures/chrome-mock.ts`): in-memory история (фейковые данные `@plq/faker` — те же шаблоны, что в Jest-моках), дерево закладок с полным CRUD, `storage.local/sync`, `runtime.getURL` с заглушкой фавиконок из статики. Устанавливается первым импортом в preview.
- Обёртки `utils/api` теперь резолвят `window.browser ?? window.chrome` **лениво** — точка инъекции моков, код приложения не зависит от порядка загрузки.
- **Композиционные стори с play-тестами**: целый экран `NewTab` (секции сами тянут историю из мока, клик по сайдбару включает edit mode — появляются заголовки секций), `Sidebar`; плюс стори для непокрытых компонентов: Loader, PinButton, Bookmark, Favicon, SidebarItem.
- Итог: **24 interaction-теста** в headless Chromium (было 14), каждый со встроенной a11y-проверкой.

### Слои тестирования (сверху вниз, всё без Chrome)

1. **Unit** — `src/utils/**` (было, 464 теста)
2. **Интеграция стора** — боевые редьюсеры + экшены + селекторы: `src/store/__tests__/store.spec.tsx`
3. **Компонентные (jsdom)** — Testing Library + jest-dom + user-event: `Button`, `Tabs` как образцы
4. **Композиционные** — Storybook play-функции + a11y (test-runner)
5. **E2E** — Playwright с собранным расширением (существующий слой, для точечных проверок)

Итого локально: **471 Jest-тест + 24 interaction-теста** — все зелёные.

### Реальные баги, пойманные новой обвязкой

- **`@plq/use-persisted-state`**: ESM-обёртка пакета теряет экспорты под webpack-interop (`import cjs from '../lib/index.js'` + `__esModule` → и named, и default импорты = `undefined`). Экран NewTab падал целиком. Обход — импорт CJS-сборки через subpath `/lib`; кандидат на фикс в самой библиотеке.
- **`Bookmark`**: кнопки действий были вложены в `<a>` — a11y-нарушение nested-interactive; вынесены в сиблинги (визуально без изменений: абсолютное позиционирование осталось).
- **`PinButton`**: иконка-кнопка без accessible name — добавлен `aria-label`.
- **Jest-мок chrome.history** вызывал метод, удалённый из `@plq/faker` 1.1 (`getHistory` → `createMockItems`) — падало бы при первом же тесте, зовущем `chrome.history.search`.
- `nanoid` 6 (ESM-only) замаплен на CJS-шим в Jest.

### Документация и CI

- **`CLAUDE.md`** (снят из `.gitignore`): карта проекта, команды, какой слой тестов для чего, конвенции, чек-лист перед коммитом — руководство для агента в облаке.
- **README**: workflow разработки — Storybook-first; `npm run dev` собирает в `dist/chrome` с автоперезагрузкой загруженного расширения (webpack-webextension-plugin); установка готового zip из артефактов CI.
- **CI**: workflow Tests дополнительно публикует `storybook-static` как артефакт (можно скачать и покликать собранный Storybook); workflow Build как и раньше публикует установочный `packages/*.zip`.
- `.rules/testing.md` и `.rules/project-overview.md` обновлены под новые слои.

### Про HMR

- UI-итерации — в Storybook (`npm run storybook`, HMR из коробки).
- В реальном Chrome — `npm run dev`: watch-сборка + автоматическая перезагрузка расширения при каждом изменении (проверено: `webpack-webextension-plugin reloading extension...`).

### Возможные следующие шаги (сознательно не в этом PR)

- Миграция сборки на Vite (+ Vitest вместо Jest → откроется faker 10, нативный ESM): в Storybook 11 webpack5-билдер будет удалён, так что направление задано. Делать это одновременно с апгрейдом зависимостей и построением обвязки было бы слишком рискованно.
- Фикс ESM-обёртки в `@plq/use-persisted-state` (upstream).

## Проверено локально

- `biome check .`, `tsc --noEmit` — чисто
- `jest` — **471/471**
- `build-storybook` + `test-storybook` (headless Chromium) — **24/24**
- `npm run build` — zip собирается; `npm run dev` — watch + автоперезагрузка работают

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1QNCiTqcvRpPq6q9XVDT2

---
_Generated by [Claude Code](https://claude.ai/code/session_01G1QNCiTqcvRpPq6q9XVDT2)_